### PR TITLE
Fix for Issue #2 - System.NullReferenceException when editing channel titles of Japanese WADs

### DIFF
--- a/ShowMiiWads/ShowMiiWads_Main.cs
+++ b/ShowMiiWads/ShowMiiWads_Main.cs
@@ -3281,7 +3281,7 @@ namespace ShowMiiWads
                     string wadfile = lvWads.SelectedItems[0].Group.Tag.ToString() + "\\" + lvWads.SelectedItems[0].Text;
                     string[] oldtitles = Wii.WadInfo.GetChannelTitles(lvWads.SelectedItems[0].Group.Tag.ToString() + "\\" + lvWads.SelectedItems[0].Text);
 
-                    if (oldtitles[1].Length != 0)
+                    if (Array.Exists(oldtitles, title => title != null && title.Length > 0))
                     {
                         string[] oldvalues = new string[] { oldtitles[0], oldtitles[1], oldtitles[2], oldtitles[3], oldtitles[4], oldtitles[5], oldtitles[6], oldtitles[7] };
                         ChannelNameDialog cld = new ChannelNameDialog();


### PR DESCRIPTION
This fix scans the entire string[] array of oldtitles for non-null elements rather than just testing the element in index 1 